### PR TITLE
feat: 페이지 이동 시 스크롤 Top 기능 추가

### DIFF
--- a/src/components/ScrollToTop/ScrollToTop.tsx
+++ b/src/components/ScrollToTop/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/ScrollToTop/index.tsx
+++ b/src/components/ScrollToTop/index.tsx
@@ -1,0 +1,3 @@
+import ScrollToTop from "./ScrollToTop";
+
+export default ScrollToTop;

--- a/src/components/TeacherCard/MyTeacherCard.tsx
+++ b/src/components/TeacherCard/MyTeacherCard.tsx
@@ -58,8 +58,8 @@ function MyTeacherCard() {
     <div>
       <ScrollContainer>
       <TeacherCard>
-      {TeacherData.map((data) => (
-      <TeacherCardBox key={data.lectureIdx} data-text ={data.lectureIdx} onClick={e => {goTeacherDetail(e)}}>
+      {TeacherData.map((data, idx) => (
+      <TeacherCardBox key={idx} data-text ={data.lectureIdx} onClick={e => {goTeacherDetail(e)}}>
         <CardTop>
             <div className='title'>{data.title}</div>
             <div className='catedory'>{data.category}</div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,11 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import { BrowserRouter,Routes,Route} from 'react-router-dom';
+import ScrollToTop from './components/ScrollToTop';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <BrowserRouter>
+      <ScrollToTop />
       <App/>              
   </BrowserRouter>
 )


### PR DESCRIPTION
### 추가 기능
- 페이지 이동하면 스크롤 현재 위치에 계속 머물러 있는 문제 수정 -> 페이지 이동하면 스크롤 맨 위로 올라갑니다.
- MyTeacherCard 에서 map 으로 뿌릴 때 index 를 data.lectureIdx 로 받으면, 프론트에서는 이 값이 고유한지 판단할 수 없기 때문에 warning 이 나타나요! 그래서 그 부분 수정했습니다!

### 추후 개선
- 해당사항 없음